### PR TITLE
feat: set formnovalidate for new recovery v2 back button

### DIFF
--- a/src/react-components/ory/helpers/node.tsx
+++ b/src/react-components/ory/helpers/node.tsx
@@ -304,10 +304,11 @@ export const Node = ({
           }
         }
 
-        // the recovery code resend button
+        // the recovery code resend/choose different address buttons
         if (
           node.meta.label?.id === 1070007 || // TODO: remove this once everyone has migrated to the fix (https://github.com/ory/kratos/pull/3067)
-          node.meta.label?.id === 1070008
+          node.meta.label?.id === 1070008 ||
+          node.meta.label?.id === 1040010
         ) {
           // on html forms the required flag on an input field will prevent the form from submitting.
           // we disable validation for this form since the resend button does not rely on any input fields


### PR DESCRIPTION
Related to https://github.com/ory-corp/cloud/pull/8826 which adds a new button which needs formnovalidate