### PR TITLE
feat: support React 19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ PRETTIER_VERSION=$(shell cat package.json | jq -r '.devDependencies["prettier"] 
 format: .bin/ory
 	.bin/ory dev headers copyright --type=open-source
 	@echo "Prettier Version: $(PRETTIER_VERSION)"
-	npx prettier@$$PRETTIER_VERSION --write .
+	npx prettier@$(PRETTIER_VERSION) --write .
 
 
 licenses: .bin/licenses node_modules  # checks open-source licenses

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -39,6 +39,10 @@
   "scripts": {
     "build": "vite build"
   },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/ory/elements.git",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -37,7 +37,7 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "vite build"
+    "build": "vite build && ORY_BUILD_FORMAT=umd vite build"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",

--- a/packages/react/vite.config.mts
+++ b/packages/react/vite.config.mts
@@ -54,7 +54,25 @@ export default defineConfig({
     },
     rollupOptions: {
       treeshake: "smallest",
-      external: ["react", "react-dom"],
+      // Externalize React AND its JSX runtime. Without the jsx-runtime entries
+      // Vite bundles React 18's automatic runtime into the dist, which emits
+      // React-18-format elements that React 19 rejects at render. Externalizing
+      // makes each consumer supply their own runtime, so @ory/elements works on
+      // both React 18 and 19.
+      external: [
+        "react",
+        "react-dom",
+        "react/jsx-runtime",
+        "react/jsx-dev-runtime",
+      ],
+      output: {
+        globals: {
+          react: "React",
+          "react-dom": "ReactDOM",
+          "react/jsx-runtime": "jsxRuntime",
+          "react/jsx-dev-runtime": "jsxDevRuntime",
+        },
+      },
     },
   },
 })

--- a/packages/react/vite.config.mts
+++ b/packages/react/vite.config.mts
@@ -9,6 +9,11 @@ import dts from "vite-plugin-dts"
 import { viteStaticCopy } from "vite-plugin-static-copy"
 import autoprefixer from "autoprefixer"
 
+// The ESM and UMD artifacts are built in two passes so they can treat React's
+// JSX runtime differently (see `external` below). `make build` / the build
+// script runs `vite build` (ESM) then `ORY_BUILD_FORMAT=umd vite build` (UMD).
+const isUmd = process.env.ORY_BUILD_FORMAT === "umd"
+
 // https://vitejs.dev/config/
 export default defineConfig({
   css: {
@@ -31,46 +36,47 @@ export default defineConfig({
         return `ory_elements__${name}${id}__${hash}`
       },
     }),
-    dts({
-      insertTypesEntry: true,
-    }),
     react(),
-    viteStaticCopy({
-      targets: [
-        {
-          src: "../../src/assets",
-          dest: "",
-        },
-      ],
-    }),
+    // Types and static assets only need to be emitted once; do it on the ESM
+    // pass so the UMD pass can append its bundle without regenerating them.
+    ...(isUmd
+      ? []
+      : [
+          dts({ insertTypesEntry: true }),
+          viteStaticCopy({
+            targets: [
+              {
+                src: "../../src/assets",
+                dest: "",
+              },
+            ],
+          }),
+        ]),
   ],
   build: {
     target: "esnext",
+    // The ESM pass runs first and cleans the output; the UMD pass appends to it.
+    emptyOutDir: !isUmd,
     lib: {
       name: "@ory/elements",
       entry: path.resolve(__dirname, "../../src/react.ts"),
-      formats: ["es", "umd"],
-      fileName: (format) => (format === "es" ? "index.mjs" : "index.umd.js"),
+      formats: [isUmd ? "umd" : "es"],
+      fileName: () => (isUmd ? "index.umd.js" : "index.mjs"),
     },
     rollupOptions: {
       treeshake: "smallest",
-      // Externalize React AND its JSX runtime. Without the jsx-runtime entries
-      // Vite bundles React 18's automatic runtime into the dist, which emits
-      // React-18-format elements that React 19 rejects at render. Externalizing
-      // makes each consumer supply their own runtime, so @ory/elements works on
-      // both React 18 and 19.
-      external: [
-        "react",
-        "react-dom",
-        "react/jsx-runtime",
-        "react/jsx-dev-runtime",
-      ],
+      // ESM additionally externalizes React's JSX runtime so the artifact uses
+      // the consumer's runtime and stays React-version-agnostic (works on React
+      // 18 and 19). UMD keeps the JSX runtime bundled because the
+      // react/jsx-runtime subpath has no UMD global; this matches the previous
+      // self-contained UMD behavior.
+      external: isUmd
+        ? ["react", "react-dom"]
+        : ["react", "react-dom", "react/jsx-runtime", "react/jsx-dev-runtime"],
       output: {
         globals: {
           react: "React",
           "react-dom": "ReactDOM",
-          "react/jsx-runtime": "jsxRuntime",
-          "react/jsx-dev-runtime": "jsxDevRuntime",
         },
       },
     },


### PR DESCRIPTION
## Summary

Makes `@ory/elements` work on **both React 18 and React 19** for module consumers (ESM/bundlers), by externalizing React's JSX runtime in the **ESM** build while keeping the **UMD** build self-contained.

## The problem

`packages/react/vite.config.mts` externalized `react`/`react-dom` but the build uses the **automatic JSX runtime**, which imports `react/jsx-runtime` — and that subpath was **not** externalized. So Vite **bundled React 18's copy of `react/jsx-runtime`** into the dist. That inlined runtime:

- reads `React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentOwner` at import time — an internal **removed in React 19** → `TypeError: Cannot read properties of undefined (reading 'ReactCurrentOwner')` on import under React 19;
- and emits **React-18-format elements**, which React 19 rejects at render: *"A React Element from an older version of React was rendered."*

`packages/react` also declared **no `peerDependencies`**, so consumers got no signal about which React they needed.

## The fix

Build ESM and UMD in two passes so they can treat the JSX runtime differently:

- **ESM** externalizes `react/jsx-runtime` (+ `react/jsx-dev-runtime`) → uses the consumer's runtime → React-version-agnostic (works on 18 and 19). This is the path bundlers (Next.js, Vite, …) consume.
- **UMD** keeps the JSX runtime bundled → self-contained, unchanged from before. (The `react/jsx-runtime` subpath has no UMD global, so externalizing it for UMD would leave script-tag consumers with undefined globals — see thread with CodeRabbit.)
- Declare the peer range — `react`/`react-dom`: `^18.0.0 || ^19.0.0`.

## Verification

- ESM (`index.mjs`): `import { jsx, jsxs, Fragment } from "react/jsx-runtime"`, no inlined `__SECRET_INTERNALS`.
- UMD (`index.umd.js`): JSX runtime bundled, no external global lookup — self-contained, no behavior change.
- Types (`index.d.ts`) and assets emitted once.
- The rebuilt ESM (built against the repo's devDep `react@18`) renders correctly in a downstream **React 19** app, and its `.d.ts` type-checks cleanly there.

This lets the consuming app drop a `pnpm patch` workaround once a release ships.

## Notes / follow-up

- `devDependencies` React stays at 18 — the ESM artifact is React-version-agnostic, so bumping it wouldn't change output, only what tests run against. A **CI test matrix against both React 18 and 19** would be a good follow-up (out of scope here).
- Includes a small **`fix: pin prettier version in make format`** commit: `make format` ran `npx prettier@$$PRETTIER_VERSION` (an unexported shell var → empty → latest prettier), which broke the format job on every PR once prettier 3.8.4 released. Happy to split this out if preferred.
- `dist/` is gitignored; this changes only the build config + peer declaration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)